### PR TITLE
Replaced deprecated pthread_yield with sched_yield in UT

### DIFF
--- a/test/unit-test/fam-api/fam_progress_mt.cpp
+++ b/test/unit-test/fam-api/fam_progress_mt.cpp
@@ -93,7 +93,7 @@ void *thr_check_fam_progress(void *arg) {
                 uint64_t progress = ctx[i]->fam_progress();
                 //#TODO: Compare fam_progress value with expected values
                 (void)progress;
-                pthread_yield();
+                sched_yield();
                 /* if (progress != 0) {
                   cout << "I/Os in Progress for context" << i << " is "
                          << progress << endl;


### PR DESCRIPTION
Fix for https://github.com/OpenFAM/OpenFAM/issues/296 issue.

### Before fix
```bash
/OpenFAM/test/unit-test/fam-api/fam_progress_mt.cpp: In function ‘void* thr_check_fam_progress(void*)’:
/OpenFAM/test/unit-test/fam-api/fam_progress_mt.cpp:96:30: error: ‘int pthread_yield()’ is deprecated: pthread_yield is deprecated, use sched_yield instead [-Werror=deprecated-declarations]
   96 |                 pthread_yield();
      |                 ~~~~~~~~~~~~~^~
In file included from /usr/include/features.h:486,
                 from /usr/include/x86_64-linux-gnu/c++/11/bits/os_defines.h:39,
                 from /usr/include/x86_64-linux-gnu/c++/11/bits/c++config.h:586,
                 from /usr/include/c++/11/bits/atomic_base.h:35,
                 from /usr/include/c++/11/atomic:41,
                 from /OpenFAM/test/unit-test/fam-api/fam_progress_mt.cpp:33:
/usr/include/pthread.h:479:12: note: declared here
```
### After fix
```bash
Consolidate compiler generated dependencies of target fam_progress_mt
[ 36%] Building CXX object test/unit-test/fam-api/CMakeFiles/fam_progress_mt.dir/fam_progress_mt.cpp.o
[ 37%] Linking CXX executable fam_progress_mt
```
